### PR TITLE
Read and write remote variant names

### DIFF
--- a/src/zcl_updownci.clas.abap
+++ b/src/zcl_updownci.clas.abap
@@ -133,7 +133,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_UPDOWNCI IMPLEMENTATION.
+CLASS zcl_updownci IMPLEMENTATION.
 
 
   METHOD build_memory.
@@ -186,6 +186,10 @@ CLASS ZCL_UPDOWNCI IMPLEMENTATION.
 
     CREATE OBJECT go_xml.
 
+    IF lo_variant->rem_var_name IS NOT INITIAL.
+      go_xml->write_remote_variant_name( lo_variant->rem_var_name ).
+    ENDIF.
+
     LOOP AT lo_variant->variant ASSIGNING <ls_variant>
         WHERE testname IN it_class.                     "#EC CI_HASHSEQ
 
@@ -207,11 +211,12 @@ CLASS ZCL_UPDOWNCI IMPLEMENTATION.
 
   METHOD create_from_xml.
 
-    DATA: lt_variant    TYPE sci_tstvar,
-          lo_variant    TYPE REF TO cl_ci_checkvariant,
-          li_attributes TYPE REF TO if_ixml_node,
-          lv_testname   TYPE sci_tstval-testname,
-          lv_version    TYPE sci_tstval-version.
+    DATA: lt_variant             TYPE sci_tstvar,
+          lo_variant             TYPE REF TO cl_ci_checkvariant,
+          li_attributes          TYPE REF TO if_ixml_node,
+          lv_testname            TYPE sci_tstval-testname,
+          lv_version             TYPE sci_tstval-version,
+          lv_remote_variant_name TYPE sci_chkv.
 
 
     lo_variant = zcl_updownci_variant=>read(
@@ -261,8 +266,11 @@ CLASS ZCL_UPDOWNCI IMPLEMENTATION.
           ev_version    = lv_version ).
     ENDWHILE.
 
+    lv_remote_variant_name = go_xml->read_remote_variant_name( ).
+
     IF iv_test = abap_false.
-      lo_variant->save( lt_variant ).
+      lo_variant->save( p_variant      = lt_variant
+                        p_rem_var_name = lv_remote_variant_name ).
     ELSE.
       lo_variant->leave_change( ).
     ENDIF.

--- a/src/zcl_updownci_xml.clas.abap
+++ b/src/zcl_updownci_xml.clas.abap
@@ -13,6 +13,8 @@ CLASS zcl_updownci_xml DEFINITION
                   iv_testname TYPE sci_tstval-testname
                   iv_version  TYPE sci_tstval-version
         RAISING   zcx_updownci_exception,
+      write_remote_variant_name
+        IMPORTING iv_remote_variant_name TYPE sci_chkv,
       read_variant
         EXPORTING ei_attributes TYPE REF TO if_ixml_node
                   ev_testname   TYPE sci_tstval-testname
@@ -22,10 +24,13 @@ CLASS zcl_updownci_xml DEFINITION
         IMPORTING ii_attributes TYPE REF TO if_ixml_node
         CHANGING  cg_data       TYPE data
         RAISING   zcx_updownci_exception,
+      read_remote_variant_name
+        RETURNING VALUE(rv_remote_variant_name) TYPE sci_chkv,
       render
         RETURNING VALUE(rv_xml) TYPE string.
 
   PRIVATE SECTION.
+    CONSTANTS gc_xml_remote_variant_name TYPE string VALUE 'REMOTE_VARIANT_NAME' ##NO_TEXT.
 
     DATA:
       mi_ixml     TYPE REF TO if_ixml,
@@ -67,7 +72,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_UPDOWNCI_XML IMPLEMENTATION.
+CLASS zcl_updownci_xml IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -439,4 +444,20 @@ CLASS ZCL_UPDOWNCI_XML IMPLEMENTATION.
     ENDIF.
 
   ENDMETHOD.
+
+  METHOD write_remote_variant_name.
+    DATA li_root_as_element TYPE REF TO if_ixml_element.
+    li_root_as_element ?= mi_root.
+
+    li_root_as_element->set_attribute_ns( name  = gc_xml_remote_variant_name
+                                          value = CONV #( iv_remote_variant_name ) ).
+  ENDMETHOD.
+
+  METHOD read_remote_variant_name.
+    DATA li_root_as_element TYPE REF TO if_ixml_element.
+    li_root_as_element ?= mi_root.
+
+    rv_remote_variant_name = li_root_as_element->get_attribute_ns( name = gc_xml_remote_variant_name ).
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/zcl_updownci_xml.clas.abap
+++ b/src/zcl_updownci_xml.clas.abap
@@ -454,7 +454,7 @@ CLASS zcl_updownci_xml IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD write_remote_variant_name.
-    DATA lv_value type string.
+    DATA lv_value TYPE string.
     lv_value = iv_remote_variant_name.
 
     mi_root->set_attribute_ns( name  = gc_xml_remote_variant_name

--- a/src/zcl_updownci_xml.clas.abap
+++ b/src/zcl_updownci_xml.clas.abap
@@ -454,8 +454,11 @@ CLASS zcl_updownci_xml IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD write_remote_variant_name.
+    DATA lv_value type string.
+    lv_value = iv_remote_variant_name.
+
     mi_root->set_attribute_ns( name  = gc_xml_remote_variant_name
-                               value = CONV #( iv_remote_variant_name ) ).
+                               value = lv_value ).
   ENDMETHOD.
 
   METHOD read_remote_variant_name.


### PR DESCRIPTION
This pull request adds support for remote variant names. The remote variant name (if found) is added to the XML element `VARIANT` as an XML attribute `REMOTE_VARIANT_NAME`.

Example source:
![image](https://github.com/larshp/upDOWNci/assets/72548231/46daa4e0-6114-4e02-9ff8-09cc9decda3a)

Result for the example:

```xml
<?xml version="1.0" encoding="utf-8"?>
<VARIANT REMOTE_VARIANT_NAME="ZNAMING"/>

```

If the variant has no remote variant name, then the attribute will not be added to the XML.