### PR TITLE
Mass-download of CI variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,26 @@ Upload and download [SAP Code Inspector](http://wiki.scn.sap.com/wiki/display/AB
 - MIT License 
 
 
-### Installation
-Copy the source code into a new report or install via [abapGit](https://github.com/larshp/abapGit)
+## Installation
+Install via [abapGit](https://github.com/larshp/abapGit).
 
-### Use
+## Use
+
+### Download and upload single variants
+
+You can utilize program `ZUPDOWNCI` to download and upload single check variants.
 
 Leave username blank for global variants.
 
 ![selection](http://larshp.github.io/upDOWNci/img/selection.png)
 
-Upload will create or add checks to the specified variant
+Upload will create or add checks to the specified variant.
 
 ![upload](http://larshp.github.io/upDOWNci/img/upload.png)
+
+### Mass-download of variants
+
+You can utilize program `ZUPDOWNCI_MASS_DOWNLOAD` to download multiple variants as a single ZIP file.
+User-specific variants are stored in a folder named after the user.
+
+If the download fails due to a specific check variant, exclude it on the selection screen.

--- a/src/zcl_updownci_convert.clas.abap
+++ b/src/zcl_updownci_convert.clas.abap
@@ -1,0 +1,27 @@
+"! <p class="shorttext synchronized">Conversions</p>
+"! <p>
+"! This class is mostly copied from ZCL_ABAPGIT_CONVERT:
+"! https://github.com/abapGit/abapGit
+"! </p>
+CLASS zcl_updownci_convert DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    CLASS-METHODS string_to_xstring_utf8
+      IMPORTING
+        iv_string         TYPE string
+      RETURNING
+        VALUE(rv_xstring) TYPE xstring
+      RAISING
+        zcx_updownci_exception.
+
+ENDCLASS.
+
+
+CLASS zcl_updownci_convert IMPLEMENTATION.
+  METHOD string_to_xstring_utf8.
+    rv_xstring = lcl_out=>convert( iv_string ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_updownci_convert.clas.locals_imp.abap
+++ b/src/zcl_updownci_convert.clas.locals_imp.abap
@@ -1,0 +1,59 @@
+CLASS lcl_out DEFINITION.
+  PUBLIC SECTION.
+    CLASS-METHODS convert
+      IMPORTING
+        !iv_string        TYPE string
+      RETURNING
+        VALUE(rv_xstring) TYPE xstring
+      RAISING
+        zcx_updownci_exception.
+  PRIVATE SECTION.
+    CLASS-DATA go_conv_new TYPE REF TO object.
+    CLASS-DATA go_conv_old TYPE REF TO object.
+ENDCLASS.
+
+CLASS lcl_out IMPLEMENTATION.
+  METHOD convert.
+    DATA lx_error TYPE REF TO cx_root.
+    DATA lv_class TYPE string.
+
+    IF go_conv_new IS INITIAL AND go_conv_old IS INITIAL.
+      TRY.
+          CALL METHOD ('CL_ABAP_CONV_CODEPAGE')=>create_out
+            RECEIVING
+              instance = go_conv_new.
+        CATCH cx_sy_dyn_call_illegal_class.
+          lv_class = 'CL_ABAP_CONV_OUT_CE'.
+          CALL METHOD (lv_class)=>create
+            EXPORTING
+              encoding = 'UTF-8'
+            RECEIVING
+              conv     = go_conv_old.
+      ENDTRY.
+    ENDIF.
+
+    TRY.
+        IF go_conv_new IS NOT INITIAL.
+          CALL METHOD go_conv_new->('IF_ABAP_CONV_OUT~CONVERT')
+            EXPORTING
+              source = iv_string
+            RECEIVING
+              result = rv_xstring.
+        ELSE.
+          CALL METHOD go_conv_old->('CONVERT')
+            EXPORTING
+              data   = iv_string
+            IMPORTING
+              buffer = rv_xstring.
+        ENDIF.
+      CATCH cx_parameter_invalid_range
+            cx_sy_codepage_converter_init
+            cx_sy_conversion_codepage
+            cx_parameter_invalid_type INTO lx_error.
+        RAISE EXCEPTION TYPE zcx_updownci_exception
+          EXPORTING
+            iv_text  = lx_error->get_text( )
+            previous = lx_error.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_updownci_convert.clas.xml
+++ b/src/zcl_updownci_convert.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_UPDOWNCI_CONVERT</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Conversions</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_updownci_file.clas.abap
+++ b/src/zcl_updownci_file.clas.abap
@@ -1,71 +1,122 @@
 CLASS zcl_updownci_file DEFINITION
   PUBLIC
-  CREATE PUBLIC .
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
-    CLASS-METHODS:
-      download
-        IMPORTING iv_default TYPE string
-                  iv_xml     TYPE string
-        RAISING   cx_bcs zcx_updownci_exception,
-      upload
-        RETURNING VALUE(rv_xml) TYPE string
-        RAISING   cx_bcs zcx_updownci_exception.
+    CLASS-METHODS download_string
+      IMPORTING
+        iv_default_file_name TYPE string
+        iv_default_extension TYPE string
+        iv_content           TYPE string
+      RAISING
+        cx_bcs zcx_updownci_exception.
 
+    CLASS-METHODS download_xstring
+      IMPORTING
+        iv_default_file_name TYPE string
+        iv_default_extension TYPE string
+        iv_content           TYPE xstring
+      RAISING
+        cx_bcs zcx_updownci_exception.
+
+    CLASS-METHODS upload
+      RETURNING
+        VALUE(rv_xml) TYPE string
+      RAISING
+        cx_bcs zcx_updownci_exception.
+
+  PRIVATE SECTION.
+    CLASS-METHODS download_to_client
+      IMPORTING
+        iv_size           TYPE i
+        iv_fullpath       TYPE string
+        VALUE(it_rawdata) TYPE solix_tab
+      RAISING
+        zcx_updownci_exception.
+
+    CLASS-METHODS file_save_dialog
+      IMPORTING
+        iv_default_file_name TYPE string
+        iv_default_extension TYPE string
+      EXPORTING
+        ev_fullpath          TYPE string
+        ev_size              TYPE i
+        ev_so_obj_len        TYPE so_obj_len
+        ev_action            TYPE i
+        et_rawdata           TYPE solix_tab
+      RAISING
+        zcx_updownci_exception.
 ENDCLASS.
 
 
+CLASS zcl_updownci_file IMPLEMENTATION.
+  METHOD download_string.
+    DATA lv_fullpath TYPE string.
+    DATA lv_size TYPE i.
+    DATA lv_so_obj_len TYPE so_obj_len.
+    DATA lv_action TYPE i.
+    DATA lt_rawdata TYPE solix_tab.
 
-CLASS ZCL_UPDOWNCI_FILE IMPLEMENTATION.
-
-
-  METHOD download.
-
-    DATA: lt_rawdata    TYPE solix_tab,
-          lv_action     TYPE i,
-          lv_so_obj_len TYPE so_obj_len,
-          lv_size       TYPE i,
-          lv_filename   TYPE string,
-          lv_path       TYPE string,
-          lv_fullpath   TYPE string.
-
-
-    cl_gui_frontend_services=>file_save_dialog(
+    file_save_dialog(
       EXPORTING
-        default_extension    = 'xml'
-        default_file_name    = iv_default
-      CHANGING
-        filename             = lv_filename
-        path                 = lv_path
-        fullpath             = lv_fullpath
-        user_action          = lv_action
-      EXCEPTIONS
-        cntl_error           = 1
-        error_no_gui         = 2
-        not_supported_by_gui = 3
-        OTHERS               = 4 ).                         "#EC NOTEXT
-    IF sy-subrc <> 0.
-      RAISE EXCEPTION TYPE zcx_updownci_exception EXPORTING iv_text = 'error from file_save_dialog'.
-    ENDIF.
+        iv_default_file_name = iv_default_file_name
+        iv_default_extension = iv_default_extension
+      IMPORTING
+        ev_fullpath          = lv_fullpath
+        ev_action            = lv_action
+        et_rawdata           = lt_rawdata ).
+
     IF lv_action = cl_gui_frontend_services=>action_cancel.
       RETURN.
     ENDIF.
 
     cl_bcs_convert=>string_to_solix(
       EXPORTING
-        iv_string = iv_xml
+        iv_string = iv_content
       IMPORTING
         et_solix  = lt_rawdata
         ev_size   = lv_so_obj_len ).
+
     lv_size = lv_so_obj_len.
 
+    download_to_client(
+        iv_size     = lv_size
+        iv_fullpath = lv_fullpath
+        it_rawdata  = lt_rawdata ).
+  ENDMETHOD.
+
+  METHOD file_save_dialog.
+    DATA lv_filename TYPE string.
+    DATA lv_path TYPE string.
+
+    cl_gui_frontend_services=>file_save_dialog(
+      EXPORTING
+        default_extension    = iv_default_extension
+        default_file_name    = iv_default_file_name
+      CHANGING
+        filename             = lv_filename
+        path                 = lv_path
+        fullpath             = ev_fullpath
+        user_action          = ev_action
+      EXCEPTIONS
+        cntl_error           = 1
+        error_no_gui         = 2
+        not_supported_by_gui = 3
+        OTHERS               = 4 ) ##NO_TEXT.
+
+    IF sy-subrc <> 0.
+      RAISE EXCEPTION TYPE zcx_updownci_exception EXPORTING iv_text = 'error from file_save_dialog'.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD download_to_client.
     cl_gui_frontend_services=>gui_download(
       EXPORTING
-      bin_filesize = lv_size
-        filename                  = lv_fullpath
+        bin_filesize              = iv_size
+        filename                  = iv_fullpath
         filetype                  = 'BIN'
       CHANGING
-        data_tab                  = lt_rawdata
+        data_tab                  = it_rawdata
       EXCEPTIONS
         file_write_error          = 1
         no_batch                  = 2
@@ -91,22 +142,45 @@ CLASS ZCL_UPDOWNCI_FILE IMPLEMENTATION.
         not_supported_by_gui      = 22
         error_no_gui              = 23
         OTHERS                    = 24 ).
+
     IF sy-subrc <> 0.
       RAISE EXCEPTION TYPE zcx_updownci_exception EXPORTING iv_text = 'error from gui_download'.
     ENDIF.
-
   ENDMETHOD.
 
+  METHOD download_xstring.
+    DATA lv_fullpath TYPE string.
+    DATA lv_action TYPE i.
+    DATA lt_rawdata TYPE solix_tab.
+
+    file_save_dialog(
+      EXPORTING
+        iv_default_file_name = iv_default_file_name
+        iv_default_extension = iv_default_extension
+      IMPORTING
+        ev_fullpath          = lv_fullpath
+        ev_action            = lv_action
+        et_rawdata           = lt_rawdata ).
+
+    IF lv_action = cl_gui_frontend_services=>action_cancel.
+      RETURN.
+    ENDIF.
+
+    lt_rawdata = cl_bcs_convert=>xstring_to_solix( iv_content ).
+
+    download_to_client(
+        iv_size     = xstrlen( iv_content )
+        iv_fullpath = lv_fullpath
+        it_rawdata  = lt_rawdata ).
+  ENDMETHOD.
 
   METHOD upload.
-
-    DATA: lv_action     TYPE i,
-          lt_data       TYPE TABLE OF text255,
-          lv_filename   TYPE string,
-          lt_file_table TYPE filetable,
-          ls_file_table LIKE LINE OF lt_file_table,
-          lv_rc         TYPE i.
-
+    DATA lv_action TYPE i.
+    DATA lt_data TYPE TABLE OF text255.
+    DATA lv_filename TYPE string.
+    DATA lt_file_table TYPE filetable.
+    DATA ls_file_table LIKE LINE OF lt_file_table.
+    DATA lv_rc TYPE i.
 
     cl_gui_frontend_services=>file_open_dialog(
       EXPORTING
@@ -163,6 +237,5 @@ CLASS ZCL_UPDOWNCI_FILE IMPLEMENTATION.
     ENDIF.
 
     CONCATENATE LINES OF lt_data INTO rv_xml.
-
-  ENDMETHOD.                    "upload
+  ENDMETHOD.
 ENDCLASS.

--- a/src/zupdownci.prog.abap
+++ b/src/zupdownci.prog.abap
@@ -86,9 +86,10 @@ CLASS lcl_app IMPLEMENTATION.
             iv_user  = p_user
             it_class = s_class[] ).
 
-          zcl_updownci_file=>download(
-            iv_default = lv_default
-            iv_xml     = lv_xml ).
+          zcl_updownci_file=>download_string(
+            iv_default_file_name = lv_default
+            iv_default_extension = 'xml'
+            iv_content           = lv_xml ).
         ELSE.
           lv_xml = zcl_updownci_file=>upload( ).
           IF lv_xml IS INITIAL.

--- a/src/zupdownci_mass_download.prog.abap
+++ b/src/zupdownci_mass_download.prog.abap
@@ -1,61 +1,72 @@
 REPORT zupdownci_mass_download.
 
-CLASS lcl_program DEFINITION CREATE PUBLIC.
+TABLES scichkv_hd.
+
+SELECT-OPTIONS s_user FOR scichkv_hd-ciuser.
+SELECT-OPTIONS s_name FOR scichkv_hd-checkvname.
+
+CLASS lcl_app DEFINITION.
 
   PUBLIC SECTION.
-    METHODS run.
-
-  PROTECTED SECTION.
+    CLASS-METHODS run.
 
   PRIVATE SECTION.
-    CONSTANTS gc_xml_file_extension TYPE string VALUE `.xml` ##NO_TEXT.
-    CONSTANTS gc_slash_replacement TYPE char01 VALUE '#'.
+    TYPES: BEGIN OF gy_check_variant,
+             ciuser     TYPE scichkv_hd-ciuser,
+             checkvname TYPE scichkv_hd-checkvname,
+           END OF gy_check_variant.
+    TYPES gy_check_variants TYPE TABLE OF gy_check_variant WITH KEY ciuser checkvname.
 
-    METHODS read_check_variants_from_db
+    CLASS-METHODS read_check_variants_from_db
       RETURNING
-        VALUE(rt_check_variants) TYPE zcl_ci2git_staging=>gy_check_variants.
+        VALUE(rt_check_variants) TYPE gy_check_variants.
 
+    CLASS-METHODS add_variant_to_zip
+      IMPORTING
+        io_zip           TYPE REF TO cl_abap_zip
+        is_check_variant TYPE gy_check_variant
+      RAISING
+        zcx_updownci_exception.
 
+    CLASS-METHODS download_zip
+      IMPORTING
+        io_zip TYPE REF TO cl_abap_zip
+      RAISING
+        cx_bcs
+        zcx_updownci_exception.
 ENDCLASS.
 
 
-CLASS lcl_program IMPLEMENTATION.
+CLASS lcl_app IMPLEMENTATION.
   METHOD run.
-    DATA lt_check_variants TYPE zcl_ci2git_staging=>gy_check_variants.
-    FIELD-SYMBOLS <ls_check_variant> TYPE zcl_ci2git_staging=>gy_check_variant.
+    DATA lt_check_variants TYPE gy_check_variants.
+    DATA lo_zip TYPE REF TO cl_abap_zip.
+    DATA lx_static TYPE REF TO cx_static_check.
+    DATA lx_exception TYPE REF TO zcx_updownci_exception.
+    FIELD-SYMBOLS <ls_check_variant> TYPE gy_check_variant.
 
     lt_check_variants = read_check_variants_from_db( ).
+    lo_zip = NEW cl_abap_zip( ).
 
-    DATA(lo_zip) = NEW cl_abap_zip( ).
+    TRY.
+        LOOP AT lt_check_variants ASSIGNING <ls_check_variant>.
+          add_variant_to_zip(
+              io_zip           = lo_zip
+              is_check_variant = <ls_check_variant> ).
+        ENDLOOP.
 
-    LOOP AT lt_check_variants ASSIGNING <ls_check_variant>.
-      TRY.
-          DATA(lv_xml) = zcl_updownci=>build_xml( iv_name = <ls_check_variant>-checkvname
-                                                  iv_user = <ls_check_variant>-ciuser ).
-        CATCH zcx_updownci_exception.
-          CONTINUE.
-      ENDTRY.
+        download_zip( lo_zip ).
+      CATCH zcx_updownci_exception INTO lx_exception.
+        MESSAGE lx_exception->iv_text TYPE 'E'.
+      CATCH cx_static_check INTO lx_static.
+        MESSAGE lx_static TYPE 'E'.
+    ENDTRY.
+  ENDMETHOD.
 
-      DATA(lv_path) = `/`.
+  METHOD download_zip.
+    DATA lv_zip_xstring TYPE xstring.
 
-      IF <ls_check_variant>-ciuser IS NOT INITIAL.
-        lv_path = |{ lv_path }{ <ls_check_variant>-ciuser }/|.
-      ENDIF.
-
-      DATA(lv_filename) = replace( val  = |{ <ls_check_variant>-checkvname }{ gc_xml_file_extension }|
-                                   sub  = '/'
-                                   with = gc_slash_replacement
-                                   occ  = 0 ).
-
-      DATA(lv_name) = |{ lv_path }{ lv_filename }|.
-
-      DATA(lv_data) = zcl_abapgit_convert=>string_to_xstring_utf8( lv_xml ).
-
-      lo_zip->add( name    = lv_name
-                   content = lv_data ).
-    ENDLOOP.
-
-    DATA(lv_zip_xstring) = lo_zip->save( ).
+    lv_zip_xstring = io_zip->save( ).
 
     zcl_updownci_file=>download_xstring(
         iv_default_file_name = 'variants'
@@ -66,10 +77,45 @@ CLASS lcl_program IMPLEMENTATION.
   METHOD read_check_variants_from_db.
     SELECT ciuser checkvname
       FROM scichkv_hd
-      INTO TABLE rt_check_variants.
+      INTO TABLE rt_check_variants
+      WHERE ciuser     IN s_user
+        AND checkvname IN s_name.
   ENDMETHOD.
 
+  METHOD add_variant_to_zip.
+    DATA lv_xml TYPE string.
+    DATA lv_path TYPE string.
+    DATA lv_filename TYPE string.
+    DATA lv_name TYPE string.
+    DATA lv_data TYPE xstring.
+    DATA lx_exception TYPE REF TO zcx_updownci_exception.
+
+    TRY.
+        lv_xml = zcl_updownci=>build_xml( iv_name = is_check_variant-checkvname
+                                                iv_user = is_check_variant-ciuser ).
+        lv_path = `/`.
+
+        IF is_check_variant-ciuser IS NOT INITIAL.
+          " Place user-specific variants in a folder named after the user
+          lv_path = |{ lv_path }{ is_check_variant-ciuser }/|.
+        ENDIF.
+
+        lv_filename = cl_http_utility=>escape_url( |{ is_check_variant-checkvname }.xml| ).
+
+        lv_name = |{ lv_path }{ lv_filename }|.
+
+        lv_data = zcl_updownci_convert=>string_to_xstring_utf8( lv_xml ).
+
+        io_zip->add( name    = lv_name
+                     content = lv_data ).
+      CATCH zcx_updownci_exception INTO lx_exception.
+        RAISE EXCEPTION TYPE zcx_updownci_exception
+          EXPORTING
+            iv_text  = |Failed to process variant { is_check_variant-ciuser } { is_check_variant-checkvname }|
+            previous = lx_exception.
+    ENDTRY.
+  ENDMETHOD.
 ENDCLASS.
 
 START-OF-SELECTION.
-  NEW lcl_program( )->run( ).
+  lcl_app=>run( ).

--- a/src/zupdownci_mass_download.prog.abap
+++ b/src/zupdownci_mass_download.prog.abap
@@ -15,11 +15,7 @@ CLASS lcl_program DEFINITION CREATE PUBLIC.
       RETURNING
         VALUE(rt_check_variants) TYPE zcl_ci2git_staging=>gy_check_variants.
 
-    METHODS download
-      IMPORTING
-        iv_xstring TYPE xstring
-      RAISING
-        cx_bcs zcx_updownci_exception.
+
 ENDCLASS.
 
 
@@ -65,24 +61,6 @@ CLASS lcl_program IMPLEMENTATION.
         iv_default_file_name = 'variants'
         iv_default_extension = 'zip'
         iv_content           = lv_zip_xstring ).
-
-*    CL_BCS_CONVERT=>xstring_to_string(
-*    EXPORTING
-*      iv_xstr   = LV_ZIP_XSTRING
-*      iv_cp     =  1100                " SAP character set identification
-*    RECEIVING
-*      rv_string = DATA(lv_string)
-*  ).
-
-    " data lv_size type i.
-    "
-    "     CALL FUNCTION 'SCMS_XSTRING_TO_BINARY'
-    "   EXPORTING
-    "     BUFFER        = LV_ZIP_XSTRING
-    "   IMPORTING
-    "     OUTPUT_LENGTH = lv_size
-    "   TABLES
-    "     BINARY_TAB    = ME->PT_ZIP_BIN_DATA.
   ENDMETHOD.
 
   METHOD read_check_variants_from_db.
@@ -91,84 +69,6 @@ CLASS lcl_program IMPLEMENTATION.
       INTO TABLE rt_check_variants.
   ENDMETHOD.
 
-  METHOD download.
-    DATA lt_rawdata TYPE solix_tab.
-    DATA lv_action TYPE i.
-*    DATA lv_so_obj_len TYPE so_obj_len.
-    DATA lv_size TYPE i.
-    DATA lv_filename TYPE string.
-    DATA lv_path TYPE string.
-    DATA lv_fullpath TYPE string.
-
-    cl_gui_frontend_services=>file_save_dialog( EXPORTING  default_extension    = 'zip'
-                                                           default_file_name    = 'export'
-                                                CHANGING   filename             = lv_filename
-                                                           path                 = lv_path
-                                                           fullpath             = lv_fullpath
-                                                           user_action          = lv_action
-                                                EXCEPTIONS cntl_error           = 1
-                                                           error_no_gui         = 2
-                                                           not_supported_by_gui = 3
-                                                           OTHERS               = 4 ) ##NO_TEXT.
-    IF sy-subrc <> 0.
-      RAISE EXCEPTION TYPE zcx_updownci_exception
-        EXPORTING
-          iv_text = 'error from file_save_dialog'.
-    ENDIF.
-    IF lv_action = cl_gui_frontend_services=>action_cancel.
-      RETURN.
-    ENDIF.
-
-    CALL FUNCTION 'SCMS_XSTRING_TO_BINARY'
-      EXPORTING
-        buffer        = iv_xstring
-      IMPORTING
-        output_length = lv_size
-      TABLES
-        binary_tab    = lt_rawdata.
-
-*    cl_bcs_convert=>string_to_solix(
-*      EXPORTING
-*        iv_string = iv_xml
-*      IMPORTING
-*        et_solix  = lt_rawdata
-*        ev_size   = lv_so_obj_len ).
-*    lv_size = lv_so_obj_len.
-
-    cl_gui_frontend_services=>gui_download( EXPORTING  bin_filesize            = lv_size
-                                                       filename                = lv_fullpath
-                                                       filetype                = 'BIN'
-                                            CHANGING   data_tab                = lt_rawdata
-                                            EXCEPTIONS file_write_error        = 1
-                                                       no_batch                = 2
-                                                       gui_refuse_filetransfer = 3
-                                                       invalid_type            = 4
-                                                       no_authority            = 5
-                                                       unknown_error           = 6
-                                                       header_not_allowed      = 7
-                                                       separator_not_allowed   = 8
-                                                       filesize_not_allowed    = 9
-                                                       header_too_long         = 10
-                                                       dp_error_create         = 11
-                                                       dp_error_send           = 12
-                                                       dp_error_write          = 13
-                                                       unknown_dp_error        = 14
-                                                       access_denied           = 15
-                                                       dp_out_of_memory        = 16
-                                                       disk_full               = 17
-                                                       dp_timeout              = 18
-                                                       file_not_found          = 19
-                                                       dataprovider_exception  = 20
-                                                       control_flush_error     = 21
-                                                       not_supported_by_gui    = 22
-                                                       error_no_gui            = 23
-                                                       OTHERS                  = 24 ).
-    IF sy-subrc <> 0.
-      RAISE EXCEPTION TYPE zcx_updownci_exception
-        EXPORTING
-          iv_text = 'error from gui_download'.
-    ENDIF.
-  ENDMETHOD.
 ENDCLASS.
 
 START-OF-SELECTION.

--- a/src/zupdownci_mass_download.prog.abap
+++ b/src/zupdownci_mass_download.prog.abap
@@ -1,0 +1,175 @@
+REPORT zupdownci_mass_download.
+
+CLASS lcl_program DEFINITION CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    METHODS run.
+
+  PROTECTED SECTION.
+
+  PRIVATE SECTION.
+    CONSTANTS gc_xml_file_extension TYPE string VALUE `.xml` ##NO_TEXT.
+    CONSTANTS gc_slash_replacement TYPE char01 VALUE '#'.
+
+    METHODS read_check_variants_from_db
+      RETURNING
+        VALUE(rt_check_variants) TYPE zcl_ci2git_staging=>gy_check_variants.
+
+    METHODS download
+      IMPORTING
+        iv_xstring TYPE xstring
+      RAISING
+        cx_bcs zcx_updownci_exception.
+ENDCLASS.
+
+
+CLASS lcl_program IMPLEMENTATION.
+  METHOD run.
+    DATA lt_check_variants TYPE zcl_ci2git_staging=>gy_check_variants.
+    FIELD-SYMBOLS <ls_check_variant> TYPE zcl_ci2git_staging=>gy_check_variant.
+
+    lt_check_variants = read_check_variants_from_db( ).
+
+    DATA(lo_zip) = NEW cl_abap_zip( ).
+
+    LOOP AT lt_check_variants ASSIGNING <ls_check_variant>.
+      TRY.
+          DATA(lv_xml) = zcl_updownci=>build_xml( iv_name = <ls_check_variant>-checkvname
+                                                  iv_user = <ls_check_variant>-ciuser ).
+        CATCH zcx_updownci_exception.
+          CONTINUE.
+      ENDTRY.
+
+      DATA(lv_path) = `/`.
+
+      IF <ls_check_variant>-ciuser IS NOT INITIAL.
+        lv_path = |{ lv_path }{ <ls_check_variant>-ciuser }/|.
+      ENDIF.
+
+      DATA(lv_filename) = replace( val  = |{ <ls_check_variant>-checkvname }{ gc_xml_file_extension }|
+                                   sub  = '/'
+                                   with = gc_slash_replacement
+                                   occ  = 0 ).
+
+      DATA(lv_name) = |{ lv_path }{ lv_filename }|.
+
+      DATA(lv_data) = zcl_abapgit_convert=>string_to_xstring_utf8( lv_xml ).
+
+      lo_zip->add( name    = lv_name
+                   content = lv_data ).
+    ENDLOOP.
+
+    DATA(lv_zip_xstring) = lo_zip->save( ).
+
+    zcl_updownci_file=>download_xstring(
+        iv_default_file_name = 'variants'
+        iv_default_extension = 'zip'
+        iv_content           = lv_zip_xstring ).
+
+*    CL_BCS_CONVERT=>xstring_to_string(
+*    EXPORTING
+*      iv_xstr   = LV_ZIP_XSTRING
+*      iv_cp     =  1100                " SAP character set identification
+*    RECEIVING
+*      rv_string = DATA(lv_string)
+*  ).
+
+    " data lv_size type i.
+    "
+    "     CALL FUNCTION 'SCMS_XSTRING_TO_BINARY'
+    "   EXPORTING
+    "     BUFFER        = LV_ZIP_XSTRING
+    "   IMPORTING
+    "     OUTPUT_LENGTH = lv_size
+    "   TABLES
+    "     BINARY_TAB    = ME->PT_ZIP_BIN_DATA.
+  ENDMETHOD.
+
+  METHOD read_check_variants_from_db.
+    SELECT ciuser checkvname
+      FROM scichkv_hd
+      INTO TABLE rt_check_variants.
+  ENDMETHOD.
+
+  METHOD download.
+    DATA lt_rawdata TYPE solix_tab.
+    DATA lv_action TYPE i.
+*    DATA lv_so_obj_len TYPE so_obj_len.
+    DATA lv_size TYPE i.
+    DATA lv_filename TYPE string.
+    DATA lv_path TYPE string.
+    DATA lv_fullpath TYPE string.
+
+    cl_gui_frontend_services=>file_save_dialog( EXPORTING  default_extension    = 'zip'
+                                                           default_file_name    = 'export'
+                                                CHANGING   filename             = lv_filename
+                                                           path                 = lv_path
+                                                           fullpath             = lv_fullpath
+                                                           user_action          = lv_action
+                                                EXCEPTIONS cntl_error           = 1
+                                                           error_no_gui         = 2
+                                                           not_supported_by_gui = 3
+                                                           OTHERS               = 4 ) ##NO_TEXT.
+    IF sy-subrc <> 0.
+      RAISE EXCEPTION TYPE zcx_updownci_exception
+        EXPORTING
+          iv_text = 'error from file_save_dialog'.
+    ENDIF.
+    IF lv_action = cl_gui_frontend_services=>action_cancel.
+      RETURN.
+    ENDIF.
+
+    CALL FUNCTION 'SCMS_XSTRING_TO_BINARY'
+      EXPORTING
+        buffer        = iv_xstring
+      IMPORTING
+        output_length = lv_size
+      TABLES
+        binary_tab    = lt_rawdata.
+
+*    cl_bcs_convert=>string_to_solix(
+*      EXPORTING
+*        iv_string = iv_xml
+*      IMPORTING
+*        et_solix  = lt_rawdata
+*        ev_size   = lv_so_obj_len ).
+*    lv_size = lv_so_obj_len.
+
+    cl_gui_frontend_services=>gui_download( EXPORTING  bin_filesize            = lv_size
+                                                       filename                = lv_fullpath
+                                                       filetype                = 'BIN'
+                                            CHANGING   data_tab                = lt_rawdata
+                                            EXCEPTIONS file_write_error        = 1
+                                                       no_batch                = 2
+                                                       gui_refuse_filetransfer = 3
+                                                       invalid_type            = 4
+                                                       no_authority            = 5
+                                                       unknown_error           = 6
+                                                       header_not_allowed      = 7
+                                                       separator_not_allowed   = 8
+                                                       filesize_not_allowed    = 9
+                                                       header_too_long         = 10
+                                                       dp_error_create         = 11
+                                                       dp_error_send           = 12
+                                                       dp_error_write          = 13
+                                                       unknown_dp_error        = 14
+                                                       access_denied           = 15
+                                                       dp_out_of_memory        = 16
+                                                       disk_full               = 17
+                                                       dp_timeout              = 18
+                                                       file_not_found          = 19
+                                                       dataprovider_exception  = 20
+                                                       control_flush_error     = 21
+                                                       not_supported_by_gui    = 22
+                                                       error_no_gui            = 23
+                                                       OTHERS                  = 24 ).
+    IF sy-subrc <> 0.
+      RAISE EXCEPTION TYPE zcx_updownci_exception
+        EXPORTING
+          iv_text = 'error from gui_download'.
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.
+
+START-OF-SELECTION.
+  NEW lcl_program( )->run( ).

--- a/src/zupdownci_mass_download.prog.abap
+++ b/src/zupdownci_mass_download.prog.abap
@@ -46,7 +46,7 @@ CLASS lcl_app IMPLEMENTATION.
     FIELD-SYMBOLS <ls_check_variant> TYPE gy_check_variant.
 
     lt_check_variants = read_check_variants_from_db( ).
-    lo_zip = NEW cl_abap_zip( ).
+    CREATE OBJECT lo_zip.
 
     TRY.
         LOOP AT lt_check_variants ASSIGNING <ls_check_variant>.

--- a/src/zupdownci_mass_download.prog.xml
+++ b/src/zupdownci_mass_download.prog.xml
@@ -16,6 +16,20 @@
      <ENTRY>Mass-download of CI variants</ENTRY>
      <LENGTH>28</LENGTH>
     </item>
+    <item>
+     <ID>S</ID>
+     <KEY>S_NAME</KEY>
+     <ENTRY>.</ENTRY>
+     <LENGTH>9</LENGTH>
+     <SPLIT>D</SPLIT>
+    </item>
+    <item>
+     <ID>S</ID>
+     <KEY>S_USER</KEY>
+     <ENTRY>.</ENTRY>
+     <LENGTH>9</LENGTH>
+     <SPLIT>D</SPLIT>
+    </item>
    </TPOOL>
   </asx:values>
  </asx:abap>

--- a/src/zupdownci_mass_download.prog.xml
+++ b/src/zupdownci_mass_download.prog.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <PROGDIR>
+    <NAME>ZUPDOWNCI_MASS_DOWNLOAD</NAME>
+    <DBAPL>S</DBAPL>
+    <SUBC>1</SUBC>
+    <FIXPT>X</FIXPT>
+    <LDBNAME>D$S</LDBNAME>
+    <UCCHECK>X</UCCHECK>
+   </PROGDIR>
+   <TPOOL>
+    <item>
+     <ID>R</ID>
+     <ENTRY>Mass-download of CI variants</ENTRY>
+     <LENGTH>28</LENGTH>
+    </item>
+   </TPOOL>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
This is the spiritual successor of #26. After I continued working on the abapGit integration, I noticed that I also need a functionality like that on a system where I don't have abapGit installed (and don't want to install it either). That's why I shifted my focus from integrating abapGit to instead downloading a ZIP file containing all of the variants.

This is still a very rough draft requiring lots of clean-up activities.

I'm not sure if I should integrate this functionality into the existing program `ZUPDOWNCI` or if it'd be better as a separate program. 

Any thoughts so far? 🙂 