### PR TITLE
Skip CI variants with errors in mass-download

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Upload will create or add checks to the specified variant.
 You can utilize program `ZUPDOWNCI_MASS_DOWNLOAD` to download multiple variants as a single ZIP file.
 User-specific variants are stored in a folder named after the user.
 
-If the download fails due to a specific check variant, exclude it on the selection screen.
+If an error occurs for a specific check variant, then it is excluded from the ZIP file and an error is displayed.

--- a/src/zupdownci_mass_download.prog.abap
+++ b/src/zupdownci_mass_download.prog.abap
@@ -48,13 +48,18 @@ CLASS lcl_app IMPLEMENTATION.
     lt_check_variants = read_check_variants_from_db( ).
     CREATE OBJECT lo_zip.
 
-    TRY.
-        LOOP AT lt_check_variants ASSIGNING <ls_check_variant>.
+    LOOP AT lt_check_variants ASSIGNING <ls_check_variant>.
+      TRY.
           add_variant_to_zip(
               io_zip           = lo_zip
               is_check_variant = <ls_check_variant> ).
-        ENDLOOP.
+        CATCH zcx_updownci_exception INTO lx_exception.
+          WRITE / lx_exception->iv_text.
+          WRITE / |Skipping check variant { <ls_check_variant>-ciuser } { <ls_check_variant>-checkvname }|.
+      ENDTRY.
+    ENDLOOP.
 
+    TRY.
         download_zip( lo_zip ).
       CATCH zcx_updownci_exception INTO lx_exception.
         MESSAGE lx_exception->iv_text TYPE 'E'.


### PR DESCRIPTION
I'm changing this behavior because having to exclude each variant one-by-one in case of errors can get very tedious if there are a lot of errors. 