### PR TITLE
Add select-option for check classes

### DIFF
--- a/src/zupdownci_mass_download.prog.abap
+++ b/src/zupdownci_mass_download.prog.abap
@@ -1,9 +1,11 @@
 REPORT zupdownci_mass_download.
 
 TABLES scichkv_hd.
+TABLES seoclass.
 
 SELECT-OPTIONS s_user FOR scichkv_hd-ciuser.
 SELECT-OPTIONS s_name FOR scichkv_hd-checkvname.
+SELECT-OPTIONS s_class FOR seoclass-clsname.
 
 CLASS lcl_app DEFINITION.
 
@@ -101,8 +103,9 @@ CLASS lcl_app IMPLEMENTATION.
     DATA lx_exception TYPE REF TO zcx_updownci_exception.
 
     TRY.
-        lv_xml = zcl_updownci=>build_xml( iv_name = is_check_variant-checkvname
-                                                iv_user = is_check_variant-ciuser ).
+        lv_xml = zcl_updownci=>build_xml( iv_name  = is_check_variant-checkvname
+                                          iv_user  = is_check_variant-ciuser
+                                          it_class = s_class[] ).
         lv_path = `/`.
 
         IF is_check_variant-ciuser IS NOT INITIAL.

--- a/src/zupdownci_mass_download.prog.xml
+++ b/src/zupdownci_mass_download.prog.xml
@@ -18,6 +18,13 @@
     </item>
     <item>
      <ID>S</ID>
+     <KEY>S_CLASS</KEY>
+     <ENTRY>.</ENTRY>
+     <LENGTH>9</LENGTH>
+     <SPLIT>D</SPLIT>
+    </item>
+    <item>
+     <ID>S</ID>
      <KEY>S_NAME</KEY>
      <ENTRY>.</ENTRY>
      <LENGTH>9</LENGTH>


### PR DESCRIPTION
I ran into the problem that some check variants still contained information about check classes that no longer exist in the system. This new select-option for the mass-download allows excluding such problematic check classes. 

The implementation is very similar to how it is implemented in program `ZUPDOWNCI`.