### PR TITLE
Potential Fix to Dump with CL_CI_TEST_PRETTY_PRINT Error

### DIFF
--- a/src/zcl_updownci.clas.abap
+++ b/src/zcl_updownci.clas.abap
@@ -344,7 +344,7 @@ CLASS zcl_updownci IMPLEMENTATION.
       ASSIGN lr_data->* TO <lg_data>.
 
       TRY.
-          IMPORT (lt_import) FROM DATA BUFFER iv_attributes.
+          IMPORT (lt_import) FROM DATA BUFFER iv_attributes ACCEPTING PADDING ACCEPTING TRUNCATION.
           IF sy-subrc <> 0.
             RAISE EXCEPTION TYPE zcx_updownci_exception EXPORTING iv_text = 'IMPORT error'.
           ENDIF.


### PR DESCRIPTION
I added 2 Stements to make the Export and Import of the CL_CI_TEST_PRETTY_PRINT Possible.
